### PR TITLE
postcss 8 : saving state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 npm-debug.log
 test/*.actual.css
+package-lock.json

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
-var postcss = require('postcss');
-
-module.exports = postcss.plugin('postcss-commas', function () {
-	return function (css) {
-		css.walkDecls(function (decl) {
+module.exports = function () {
+	return {
+		postcssPlugin: 'postcss-commas',
+		Declaration: function (decl) {
 			decl.raws.between = decl.raws.between.replace(/^([\S\s]+?)(\s*:\s*)$/, function ($0, $1, $2) {
 				decl.prop = decl.prop.replace(/\s*,\s*$/, '');
 
@@ -16,6 +15,8 @@ module.exports = postcss.plugin('postcss-commas', function () {
 
 				return $2;
 			});
-		});
+		}
 	};
-});
+};
+
+module.exports.postcss = true;

--- a/package.json
+++ b/package.json
@@ -18,14 +18,15 @@
   "repository": "jonathantneal/postcss-commas",
   "homepage": "https://github.com/jonathantneal/postcss-commas#readme",
   "bugs": "https://github.com/jonathantneal/postcss-commas/issues",
-  "dependencies": {
-    "postcss": "^5.0.14"
-  },
   "devDependencies": {
     "eslint": "^1.10.3",
     "jscs": "^2.8.0",
+    "postcss": "^8.3.4",
     "tap-spec": "^4.1.1",
     "tape": "^4.4.0"
+  },
+  "peerDependencies": {
+    "postcss": ">= 8.1"
   },
   "scripts": {
     "lint": "eslint . && jscs .",
@@ -33,7 +34,6 @@
     "test": "npm run lint && npm run tape"
   },
   "engines": {
-    "iojs": ">=2.0.0",
-    "node": ">=0.12.0"
+    "node": ">=12"
   }
 }

--- a/test.js
+++ b/test.js
@@ -12,7 +12,8 @@ var dir   = './test/';
 var fs      = require('fs');
 var path    = require('path');
 var plugin  = require('./');
-var test    = require('tape');
+var test = require('tape');
+var postcss = require('postcss');
 
 Object.keys(tests).forEach(function (name) {
 	var parts = tests[name];
@@ -50,7 +51,9 @@ Object.keys(tests).forEach(function (name) {
 				fs.writeFileSync(expectPath, expectCSS);
 			}
 
-			plugin.process(inputCSS, options).then(function (result) {
+			postcss([
+				plugin
+			]).process(inputCSS, options).then(function (result) {
 				var actualCSS = result.css;
 
 				if (debug) {


### PR DESCRIPTION
Seems incompatible with PostCSS 8.

Might be better to archive?

```
❯ npm run test

> postcss-commas@1.0.0 test
> npm run lint && npm run tape


> postcss-commas@1.0.0 lint
> eslint . && jscs .

(node:67476) Warning: Accessing non-existent property 'padLevels' of module exports inside circular dependency
(Use `node --trace-warnings ...` to show where the warning was created)

> postcss-commas@1.0.0 tape
> tape test.js | tap-spec


  postcss-commas

Without `from` option PostCSS could generate wrong source map and will not find Browserslist config. Set it to CSS file path or to `undefined` to prevent this warning.
postcss-commas/node_modules/postcss/lib/input.js:123
      result = new CssSyntaxError(
               ^

CssSyntaxError: <css input>:3:7: Unknown word
    at Input.error (postcss-commas/node_modules/postcss/lib/input.js:123:16)
    at Parser.unknownWord (postcss-commas/node_modules/postcss/lib/parser.js:518:22)
    at Parser.decl (postcss-commas/node_modules/postcss/lib/parser.js:201:16)
    at Parser.other (postcss-commas/node_modules/postcss/lib/parser.js:115:18)
    at Parser.parse (postcss-commas/node_modules/postcss/lib/parser.js:59:16)
    at parse (postcss-commas/node_modules/postcss/lib/parse.js:11:12)
    at new LazyResult (postcss-commas/node_modules/postcss/lib/lazy-result.js:133:16)
    at Processor.process (postcss-commas/node_modules/postcss/lib/processor.js:36:12)
    at postcss-commas/test.js:56:7
    at Array.forEach (<anonymous>) {
  reason: 'Unknown word',
  source: '.foo {\n\tposition: absolute;\n\ttop, left: 0;\n\tmargin, padding: 1em;\n}\n',
  line: 3,
  column: 7,
  input: {
    line: 3,
    column: 7,
    source: '.foo {\n\tposition: absolute;\n\ttop, left: 0;\n\tmargin, padding: 1em;\n}\n'
  }
}

```